### PR TITLE
Add cache-control header to mark blobs as immutable

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -227,6 +227,7 @@ pub async fn get_blob_handler(
     Response::builder()
         .status(StatusCode::OK)
         .header("Content-Type", content_type)
+        .header("Cache-Control", "max-age=31536000, immutable")
         .body(file_contents.into())
         .unwrap()
 }


### PR DESCRIPTION
Browsers could cache the blobs forever because they are addressed by SHA256 hash, and thus a change in the file would change the filename. Add a cache control header for 365 days=31536000 seconds, and add the immutable fflag.
(see also https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control )