### PR TITLE
Implement HEAD for /upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It stores files right to disk and stores metadata in a sqlite database.
 | BUD-02 | ✅      |
 | BUD-03 | N/A    |
 | BUD-04 | ✅      |
+| BUD-06 | ✅      |
 
 
 ## Getting Started


### PR DESCRIPTION
Factor out the checking if uploading is allowed to a function `upload_blob_prechecks`, use this in the `PUT` handler, as well as the new `HEAD` handler `upload_head_handler`.

Closes #9. Fixes the current compatibility issue with nostrudel-next.