### PR TITLE
Add x reason header to error responses

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -41,7 +41,6 @@ pub struct AuthEvent {
     pub sig: String,
 }
 
-/// Used in authorization header inspection
 fn build_unauthorized_error_response(message: &str) -> Response {
     build_error_response(StatusCode::UNAUTHORIZED, message)
 }

--- a/src/utilities/validation.rs
+++ b/src/utilities/validation.rs
@@ -23,7 +23,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Error::InvalidKind(kind) => write!(f, "Invalid kind: {}", kind),
+            Error::InvalidKind(kind) => write!(f, "Authorization event has invalid kind: {}", kind),
             Error::AuthEventExpired => write!(f, "Authorization event expired"),
             Error::ExpirationTagMissing => write!(
                 f,


### PR DESCRIPTION
Refactors handlers to stop returning JSON body in error responses and instead set the X-Reason header as per BUD-01.
Adds a bunch of tests for the HEAD /upload endpoint to ensure that's also tested properly.

Fixes #19.