### PR TITLE
Add extension for known MIME types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,7 @@ dependencies = [
  "clap",
  "hex",
  "http-body-util",
+ "mime2ext",
  "nostr-sdk",
  "reqwest",
  "serde",
@@ -1349,6 +1350,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime2ext"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "515a63dc9666c865e848b043ab52fe9a5c713ae89cde4b5fbaae67cfd614b93a"
 
 [[package]]
 name = "minimal-lexical"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ clap = { version = "4.5.21", features = ["derive"] }
 nostr-sdk = "0.36.0"
 http-body-util = "0.1.2"
 tempfile = "3.14.0"
+mime2ext = "0.1.53"
 
 [dev-dependencies]
 tower = { version = "0.5.1", features = ["util"] }


### PR DESCRIPTION
On upload, add an extension based on the MIME type, using the mime2ext crate.

Also check this in the `upload_blob_handler_test` test.

Closes #7.