### PR TITLE
Feature/add range header support

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1029,7 +1029,7 @@ mod tests {
             &file_hash,
             Bytes::from(file_contents.to_vec()),
         )
-            .unwrap();
+        .unwrap();
 
         // Send a GET request with a Range header to retrieve the blob.
         let response = app


### PR DESCRIPTION
Adds support for range headers. This will enable Damus users (iOS devices in general?) to consume media from cherry-servers. 

Closes #31.